### PR TITLE
fix: logo icon on mobile does not stretch anymore

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -217,7 +217,7 @@ const App = () => {
   return html`
     <div class="p-4">
       <div class="flex align-center mb-4">
-        <img class="w-10 sm:w-20 mr-3" src=${svgLogo} alt="logo" />
+        <img class="w-10 sm:w-20 mr-3 object-contain" src=${svgLogo} alt="logo" />
         <h1 class="font-medium leading-tight text-2xl sm:text-4xl lg:text-5xl leading-none">Anonymous youtube playlist generator</h1>
       </div>
       <p class="mb-4">Create youtube playlists without a google account</p>


### PR DESCRIPTION
Resolve #16

![immagine](https://user-images.githubusercontent.com/41837640/170781457-85f521fb-8456-4683-aa55-79a2d1798d06.png)
