### PR TITLE
Issue 35 Update youtube url validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .parcel-cache
+.idea
 dist

--- a/src/components/App/functions.js
+++ b/src/components/App/functions.js
@@ -40,10 +40,7 @@ const useFunctions = ({
 
   const isRepeatedUrl = (url) => playList.some(item => item.url === url)
 
-  const isYoutubeURL = (url) =>
-    url.includes(baseYoutubeURL) ||
-    url.includes('https://www.youtube.com') ||
-    url.includes('youtube.com')
+  const isYoutubeURL = (url) => url.match(/^https:\/\/(www|m)\.youtube\.com\/watch\?v=.+/);
 
   const showWarningPopup = (text) => {
     openPopup({
@@ -62,7 +59,7 @@ const useFunctions = ({
     if (isRepeatedUrl(videoUrl)) {
       showWarningPopup('URL already added')
     } else if (!isYoutubeURL(videoUrl)) {
-      showWarningPopup('It should be a youtube URL')
+      showWarningPopup('Invalid youtube URL')
     } else {
       updatePlayList([...playList, {
         url: videoUrl,


### PR DESCRIPTION
Close #35 

Updated to use a regex which covers both the urls mentioned in above issue.

- By using a regex, able to ensure no prepended data exists in the url. 
Example: This will now disallow `abcdehttps://www.youtube.com/watch?v=`
This will also disallow blank urls with no video id such as: `https://www.youtube.com/watch?v=`

Valid Urls. 

```
https://www.youtube.com/watch?v=dQw4w9WgXcQ
https://m.youtube.com/watch?v=dQw4w9WgXcQ
```

- Updated the error message to `Invalid youtube URL` since youtube urls with no video id is disallowed with this change.

- Updated `.gitignore` to ignore `.idea` folder to aid developers that uses Jetbrain IDEs.

